### PR TITLE
feat: Implement option for cookie based JWT  / refresh tokens

### DIFF
--- a/SyntriceEShop.API/Controllers/IUserController.cs
+++ b/SyntriceEShop.API/Controllers/IUserController.cs
@@ -7,7 +7,7 @@ namespace SyntriceEShop.API.Controllers;
 public interface IUserController
 {
     Task<IActionResult> RegisterAsync([FromBody] UserRegisterRequestDTO userRegisterRequestDto);
-    Task<IActionResult> LoginAsync([FromBody] UserLoginRequestDTO userLoginRequestDto);
+    Task<IActionResult> LoginAsync([FromBody] UserLoginRequestDTO userLoginRequestDto, [FromQuery] bool useCookies = false);
 
     Task<IActionResult> RefreshAsync([FromBody] UserRefreshRequestDTO userRefreshRequestDto);
 }

--- a/SyntriceEShop.API/Controllers/IUserController.cs
+++ b/SyntriceEShop.API/Controllers/IUserController.cs
@@ -9,5 +9,5 @@ public interface IUserController
     Task<IActionResult> RegisterAsync([FromBody] UserRegisterRequestDTO userRegisterRequestDto);
     Task<IActionResult> LoginAsync([FromBody] UserLoginRequestDTO userLoginRequestDto, [FromQuery] bool useCookies = false);
 
-    Task<IActionResult> RefreshAsync([FromBody] UserRefreshRequestDTO userRefreshRequestDto);
+    Task<IActionResult> RefreshAsync([FromBody] UserRefreshRequestDTO userRefreshRequestDto, [FromQuery] bool useCookies = false);
 }

--- a/SyntriceEShop.API/Controllers/UserController.cs
+++ b/SyntriceEShop.API/Controllers/UserController.cs
@@ -1,6 +1,8 @@
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using SyntriceEShop.API.ApplicationOptions;
 using SyntriceEShop.API.Models.UserModel;
 using SyntriceEShop.API.Services;
 using SyntriceEShop.API.Services.UserServices;
@@ -9,7 +11,7 @@ namespace SyntriceEShop.API.Controllers;
 
 [ApiController]
 [Route("api/user")]
-public class UserController(IUserService userService) : ControllerBase, IUserController
+public class UserController(IUserService userService, IOptions<JWTOptions> jwtOptions) : ControllerBase, IUserController
 {
     [HttpPost]
     [Route("register")]
@@ -30,21 +32,60 @@ public class UserController(IUserService userService) : ControllerBase, IUserCon
 
     [HttpPost]
     [Route("login")]
-    public async Task<IActionResult> LoginAsync([FromBody] UserLoginRequestDTO userLoginRequestDto)
+    public async Task<IActionResult> LoginAsync([FromBody] UserLoginRequestDTO userLoginRequestDto,
+        [FromQuery] bool useCookies = false)
     {
         var result = await userService.LoginAsync(userLoginRequestDto);
-        
-        switch (result.Type)
+
+        if (result is { Type: ServiceResponseType.Success, Value: not null })
         {
-            case ServiceResponseType.Success:
+            //  Whether to send the tokens as cookies or not
+            if (useCookies)
+            {
+                // Set cookies for both access token and refresh token
+                Response.Cookies.Append("accessToken", result.Value.AccessToken, new CookieOptions
+                {
+                    Expires = DateTimeOffset.UtcNow.AddMinutes(jwtOptions.Value.ExpirationInMinutes),
+                    HttpOnly = true,
+                    IsEssential = true,
+                    Secure = true,
+                    // unfortunately we have to use SameSiteMode.None as this is an API and will be called by a separate
+                    // front end server likely on a different domain. 
+                    SameSite = SameSiteMode.None 
+                });
+                
+                Response.Cookies.Append("refreshToken", result.Value.RefreshToken, new CookieOptions
+                {
+                    Expires = DateTimeOffset.UtcNow.AddDays(jwtOptions.Value.RefreshTokenExpirationInDays),
+                    HttpOnly = true,
+                    IsEssential = true,
+                    Secure = true,
+                    // unfortunately we have to use SameSiteMode.None as this is an API and will be called by a separate
+                    // front end server likely on a different domain. 
+                    SameSite = SameSiteMode.None 
+                });
+                return Ok();
+            }
+            else
+            {
+                // Send the tokens in the response rather than as cookies
                 return Ok(result.Value);
-            case ServiceResponseType.NotFound:
-                return NotFound(result.Message);
-            case ServiceResponseType.InvalidCredentials:
-                return Unauthorized(result.Message);
-            default:
-                return StatusCode(500); // Fallback response
+            }
+
+            return Ok(result.Value);
         }
+
+        if (result.Type == ServiceResponseType.NotFound)
+        {
+            return NotFound(result.Message);
+        }
+
+        if (result.Type == ServiceResponseType.InvalidCredentials)
+        {
+            return Unauthorized(result.Message);
+        }
+
+        return StatusCode(500);
     }
 
     [HttpPost]
@@ -52,7 +93,7 @@ public class UserController(IUserService userService) : ControllerBase, IUserCon
     public async Task<IActionResult> RefreshAsync([FromBody] UserRefreshRequestDTO userRefreshRequestDto)
     {
         var result = await userService.RefreshAsync(userRefreshRequestDto);
-        
+
         switch (result.Type)
         {
             case ServiceResponseType.Success:
@@ -70,12 +111,14 @@ public class UserController(IUserService userService) : ControllerBase, IUserCon
     public async Task<IActionResult> RevokeRefreshTokensAsync([FromRoute] int id)
     {
         // check if user matches logged-in user
-       var userId = int.TryParse(HttpContext.User.FindFirstValue(ClaimTypes.NameIdentifier), out int parsed) ? parsed : 0;
-       if (id != userId)
-       {
-           return Unauthorized();
-       }
-        
+        var userId = int.TryParse(HttpContext.User.FindFirstValue(ClaimTypes.NameIdentifier), out int parsed)
+            ? parsed
+            : 0;
+        if (id != userId)
+        {
+            return Unauthorized();
+        }
+
         var result = await userService.RevokeRefreshTokensAsync(id);
 
         switch (result.Type)
@@ -85,5 +128,15 @@ public class UserController(IUserService userService) : ControllerBase, IUserCon
             default:
                 return StatusCode(500); // Fallback response
         }
+    }
+
+    // Test authentication
+    [HttpGet]
+    [Authorize]
+    [Route("test-authentication")]
+    public async Task<IActionResult> TestAuthenticationAsync()
+    {
+        var username = HttpContext.User.FindFirstValue("username");
+        return Ok($"Hi there, {username}. You are authenticated!");
     }
 }

--- a/SyntriceEShop.API/Models/UserModel/UserLoginResponseDTO.cs
+++ b/SyntriceEShop.API/Models/UserModel/UserLoginResponseDTO.cs
@@ -2,6 +2,6 @@ namespace SyntriceEShop.API.Models.UserModel;
 
 public class UserLoginResponseDTO
 {
-    public string AccessToken { get; set; }
-    public string RefreshToken { get; set; }
+    public string AccessToken { get; set; } = string.Empty;
+    public string RefreshToken { get; set; } = string.Empty;
 }

--- a/SyntriceEShop.Tests/API/Controllers/UserControllerTests.cs
+++ b/SyntriceEShop.Tests/API/Controllers/UserControllerTests.cs
@@ -1,6 +1,9 @@
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
 using NSubstitute;
 using Shouldly;
+using SyntriceEShop.API.ApplicationOptions;
 using SyntriceEShop.API.Controllers;
 using SyntriceEShop.API.Models.UserModel;
 using SyntriceEShop.API.Services;
@@ -13,12 +16,29 @@ public class UserControllerTests
 {
     private IUserService _userService;
     private UserController _userController;
+    private IOptions<JWTOptions> _options;
     
     [SetUp]
     public void Setup()
     {
         _userService = Substitute.For<IUserService>();
-        _userController = new UserController(_userService);
+        _options = Substitute.For<IOptions<JWTOptions>>();
+        var jwtOptions = GetDefaultJWTOptions();
+        _options.Value.Returns(jwtOptions);
+        _userController = new UserController(_userService, _options);
+    }
+    
+    public static JWTOptions GetDefaultJWTOptions()
+    {
+        return new JWTOptions()
+        {
+            SecretKey = "d6bW9fMV3tCx7FAZpxc5doDpIRbWkxSk", 
+            Issuer = "automated", 
+            Audience = "test",
+            ExpirationInMinutes = 30,
+            RefreshTokenSize = 32,
+            RefreshTokenExpirationInDays = 7
+        };
     }
 
     [TestFixture]
@@ -131,6 +151,27 @@ public class UserControllerTests
             // Assert
             response.ShouldBeOfType(typeof(UnauthorizedObjectResult));
         }
+        
+        [Test]
+        public async Task WhenUseCookiesTrue_ReturnsRefreshTokenCookie()
+        {
+            // TODO
+            Assert.Ignore();
+        }
+
+        [Test]
+        public async Task WhenUseCookiesTrue_ReturnsAccessTokenCookie()
+        {
+            // TODO
+            Assert.Ignore();
+        }
+
+        [Test]
+        public async Task WhenUseCookiesTrue_ReturnsEmptyBody()
+        {
+            // TODO
+            Assert.Ignore();
+        }
     }
 
     [TestFixture]
@@ -186,6 +227,4 @@ public class UserControllerTests
             resultValue.ShouldBe(userRefreshResponseDTO);
         }
     }
-
-    
 }


### PR DESCRIPTION
Implement the option to use http only secure cookies containing JWT and refresh tokens, as well as jwt from Authorization header / returning tokens in API response bodies.